### PR TITLE
fix route:list artisan command

### DIFF
--- a/src/Http/Controllers/WireController.php
+++ b/src/Http/Controllers/WireController.php
@@ -17,7 +17,9 @@ class WireController
     public function __construct(EnvironmentConfig $config)
     {
         if (empty($config->authKey()) || request()->header('wire-key') !== $config->authKey()) {
-            abort(403);
+            if (strpos(php_sapi_name(), 'cli') !== false) {
+                abort(403);
+            }
         }
     }
 

--- a/src/Http/Controllers/WireController.php
+++ b/src/Http/Controllers/WireController.php
@@ -17,7 +17,7 @@ class WireController
     public function __construct(EnvironmentConfig $config)
     {
         if (empty($config->authKey()) || request()->header('wire-key') !== $config->authKey()) {
-            if (strpos(php_sapi_name(), 'cli') !== false) {
+            if (strpos(php_sapi_name(), 'cli') === false) {
                 abort(403);
             }
         }


### PR DESCRIPTION
When running `php artisan route:list` you get an exception now:

php artisan route:list -v

``` bash
   Symfony\Component\HttpKernel\Exception\HttpException

  at vendor/laravel/framework/src/Illuminate/Foundation/Application.php:1132
    1128▕         if ($code == 404) {
    1129▕             throw new NotFoundHttpException($message);
    1130▕         }
    1131▕
  ➜ 1132▕         throw new HttpException($code, $message, null, $headers);
    1133▕     }
    1134▕
    1135▕     /**
    1136▕      * Register a terminating callback with the application.

  1   vendor/laravel/framework/src/Illuminate/Foundation/helpers.php:44
      Illuminate\Foundation\Application::abort()

```